### PR TITLE
fix: multi-select maxrowcount not available

### DIFF
--- a/src/select/multi-select/multi-select.component.scss
+++ b/src/select/multi-select/multi-select.component.scss
@@ -20,7 +20,7 @@ $block: aui-multi-select;
     );
 
     &--#{$key} {
-      height: map-get($map, height);
+      min-height: map-get($map, height);
       font-size: map-get($map, font-size);
       line-height: map-get($map, line-height);
       padding-right: calc(


### PR DESCRIPTION
直接设置高度导致内容无法撑开容器，从而造成Maxrowcount失效