### PR TITLE
feat: rm normal table  overflow  mv scroll shadow

### DIFF
--- a/.changeset/fuzzy-scissors-hunt.md
+++ b/.changeset/fuzzy-scissors-hunt.md
@@ -1,0 +1,5 @@
+---
+"@alauda/ui": minor
+---
+
+feat: remove normal table overflow property, scrollShadow set table overflow auto, rename scrollShadow directive to scrollable, add table header sticky to parent story

--- a/src/table/table-scroll.directive.ts
+++ b/src/table/table-scroll.directive.ts
@@ -49,21 +49,21 @@ export class TableScrollWrapperDirective {
 }
 
 @Directive({
-  selector: '[auiTableScrollShadow]',
+  selector: '[auiTableScrollable]',
   providers: [
-    { provide: CdkScrollable, useExisting: TableScrollShadowDirective },
+    { provide: CdkScrollable, useExisting: TableScrollableDirective },
   ],
 })
-export class TableScrollShadowDirective
+export class TableScrollableDirective
   extends CdkScrollable
   implements AfterViewInit, OnDestroy
 {
-  scrollShadow$$ = new BehaviorSubject<boolean>(false);
+  scrollShadow$$ = new BehaviorSubject<boolean>(true);
 
   destroy$$ = new Subject<void>();
 
   @Input()
-  set auiTableScrollShadow(scrollShadow: boolean | '') {
+  set auiTableScrollable(scrollShadow: boolean | '') {
     this.scrollShadow$$.next(coerceAttrBoolean(scrollShadow));
   }
 

--- a/src/table/table-scroll.scss
+++ b/src/table/table-scroll.scss
@@ -33,6 +33,11 @@ $stickyCssClass: 'aui-table-sticky';
 
 // style for vertical shadow
 .aui-table__scroll-shadow {
+  &.aui-table {
+    overflow: auto;
+    @include scroll-bar;
+  }
+
   &.hasTableTopShadow:before {
     content: '';
     position: sticky;

--- a/src/table/table.component.scss
+++ b/src/table/table.component.scss
@@ -8,8 +8,6 @@
 
   background-color: use-rgb(n-9);
   border-radius: use-var(border-radius-l);
-  overflow: auto;
-  @include scroll-bar;
 
   &__row,
   &__header-row {

--- a/src/table/table.module.ts
+++ b/src/table/table.module.ts
@@ -22,7 +22,7 @@ import {
 import { TableRowDefDirective } from './table-row-def.directive';
 import { TableRowComponent } from './table-row.component';
 import {
-  TableScrollShadowDirective,
+  TableScrollableDirective,
   TableScrollWrapperDirective,
 } from './table-scroll.directive';
 import { TableComponent } from './table.component';
@@ -42,7 +42,7 @@ import { TableComponent } from './table.component';
     TableHeaderRowDefDirective,
     TableHeaderCellDefDirective,
     TableColumnDefDirective,
-    TableScrollShadowDirective,
+    TableScrollableDirective,
     TablePlaceholderOutletDirective,
     TablePlaceholderDefDirective,
     TableScrollWrapperDirective,
@@ -60,7 +60,7 @@ import { TableComponent } from './table.component';
     TableHeaderRowDefDirective,
     TableHeaderCellDefDirective,
     TableColumnDefDirective,
-    TableScrollShadowDirective,
+    TableScrollableDirective,
     TablePlaceholderOutletDirective,
     TablePlaceholderDefDirective,
     TableScrollWrapperDirective,

--- a/stories/table/sticky-columns/sticky-columns-demo.component.html
+++ b/stories/table/sticky-columns/sticky-columns-demo.component.html
@@ -16,7 +16,7 @@
 <div auiTableScrollWrapper="280px">
   <aui-table
     [dataSource]="dataSource"
-    auiTableScrollShadow
+    auiTableScrollable
   >
     <ng-container
       auiTableColumnDef="no"

--- a/stories/table/sticky-headers.components.ts
+++ b/stories/table/sticky-headers.components.ts
@@ -4,42 +4,44 @@ import { DATA_SOURCE } from './data';
 
 @Component({
   template: `
-    <aui-table
-      style="max-height: 300px;overflow: auto;"
-      auiTableScrollShadow
-      [dataSource]="dataSource"
-    >
-      <ng-container auiTableColumnDef="id">
-        <aui-table-header-cell *auiTableHeaderCellDef>
-          No.
-        </aui-table-header-cell>
-        <aui-table-cell *auiTableCellDef="let item">
-          <div>{{ item.id }}</div>
-        </aui-table-cell>
-      </ng-container>
-      <ng-container auiTableColumnDef="name">
-        <aui-table-header-cell *auiTableHeaderCellDef>
-          Name
-        </aui-table-header-cell>
-        <aui-table-cell *auiTableCellDef="let item">
-          <div>{{ item.name }}</div>
-        </aui-table-cell>
-      </ng-container>
-      <ng-container auiTableColumnDef="value">
-        <aui-table-header-cell *auiTableHeaderCellDef>
-          Value
-        </aui-table-header-cell>
-        <aui-table-cell *auiTableCellDef="let item">
-          {{ item.value }}
-        </aui-table-cell>
-      </ng-container>
-      <aui-table-header-row
-        *auiTableHeaderRowDef="['id', 'name', 'value']; sticky: true"
-      ></aui-table-header-row>
-      <aui-table-row
-        *auiTableRowDef="let row; columns: ['id', 'name', 'value']"
-      ></aui-table-row>
-    </aui-table>
+    <div auiTableScrollWrapper>
+      <aui-table
+        style="max-height: 300px;overflow: auto;"
+        auiTableScrollable
+        [dataSource]="dataSource"
+      >
+        <ng-container auiTableColumnDef="id">
+          <aui-table-header-cell *auiTableHeaderCellDef>
+            No.
+          </aui-table-header-cell>
+          <aui-table-cell *auiTableCellDef="let item">
+            <div>{{ item.id }}</div>
+          </aui-table-cell>
+        </ng-container>
+        <ng-container auiTableColumnDef="name">
+          <aui-table-header-cell *auiTableHeaderCellDef>
+            Name
+          </aui-table-header-cell>
+          <aui-table-cell *auiTableCellDef="let item">
+            <div>{{ item.name }}</div>
+          </aui-table-cell>
+        </ng-container>
+        <ng-container auiTableColumnDef="value">
+          <aui-table-header-cell *auiTableHeaderCellDef>
+            Value
+          </aui-table-header-cell>
+          <aui-table-cell *auiTableCellDef="let item">
+            {{ item.value }}
+          </aui-table-cell>
+        </ng-container>
+        <aui-table-header-row
+          *auiTableHeaderRowDef="['id', 'name', 'value']; sticky: true"
+        ></aui-table-header-row>
+        <aui-table-row
+          *auiTableRowDef="let row; columns: ['id', 'name', 'value']"
+        ></aui-table-row>
+      </aui-table>
+    </div>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/stories/table/table.stories.mdx
+++ b/stories/table/table.stories.mdx
@@ -152,6 +152,64 @@ Table 组件基于 CdkTable 开发, 加了一些 alauda 自定义的表格样式
   </Story>
 </Canvas>
 
+## Header 相对父级元素固定
+
+<Canvas>
+  <Story
+    name="Sticky To Parent"
+    height="600px"
+  >
+    {{
+      template: /* HTML */ `
+        <div style="height:300px;overflow:auto">
+          <h1>Sticky To Parent</h1>
+          <aui-table [dataSource]="dataSource">
+            <ng-container auiTableColumnDef="id">
+              <aui-table-header-cell *auiTableHeaderCellDef>
+                No.
+              </aui-table-header-cell>
+              <aui-table-cell *auiTableCellDef="let item">
+                <div>{{ item.id }}</div>
+              </aui-table-cell>
+            </ng-container>
+            <ng-container auiTableColumnDef="name">
+              <aui-table-header-cell *auiTableHeaderCellDef>
+                Name
+              </aui-table-header-cell>
+              <aui-table-cell
+                *auiTableCellDef="let item"
+                direction="column"
+              >
+                {{ item.name }}
+                <div style="font-size: 12px;color: #96989b;line-height: 16px;">
+                  {{ item.displayName }}
+                </div>
+              </aui-table-cell>
+            </ng-container>
+            <ng-container auiTableColumnDef="value">
+              <aui-table-header-cell *auiTableHeaderCellDef>
+                Value
+              </aui-table-header-cell>
+              <aui-table-cell *auiTableCellDef="let item">
+                {{ item.value }}
+              </aui-table-cell>
+            </ng-container>
+            <aui-table-header-row
+              *auiTableHeaderRowDef="['id', 'name', 'value']; sticky: true"
+            ></aui-table-header-row>
+            <aui-table-row
+              *auiTableRowDef="let row; columns: ['id', 'name', 'value'];"
+            ></aui-table-row>
+          </aui-table>
+        </div>
+      `,
+      props: {
+        dataSource: DATA_SOURCE,
+      },
+    }}
+  </Story>
+</Canvas>
+
 ## Sticky Columns 固定
 
 <Canvas>
@@ -173,7 +231,7 @@ Table 组件基于 CdkTable 开发, 加了一些 alauda 自定义的表格样式
 
 ## Directives
 
-| 名称                  | 作用范围         | 描述                                                        |
-| --------------------- | ---------------- | ----------------------------------------------------------- |
-| auiTableScrollWrapper | aui-table 的父级 | 固定列时候需要在 aui-table 的外层包裹一层，提供左右滚动效果 |
-| auiTableScrollShadow  | aui-table        | 固定头部是，提供上下阴影滚动效果                            |
+| 名称                  | 作用范围         | 描述                                                                                  |
+| --------------------- | ---------------- | ------------------------------------------------------------------------------------- |
+| auiTableScrollWrapper | aui-table 的父级 | 固定列时候需要在 aui-table 的外层包裹一层，提供左右滚动效果                           |
+| auiTableScrollable    | aui-table        | 表格内滚动指令，继承 cdkScrollable 指令，提供上下阴影滚动效果，固定表头时相对表格定位 |


### PR DESCRIPTION
1. `aui-table`组件默认不设置`overflow`，即`overflow:visible`
  直接使用`aui-table`, 无法设置定高，只能由内容撑开高度，实现改动之前的的表格定高溢出内滚动需要配合`auiTableScrollable`指令

2. 新增`story:Header 相对父级元素固定`
 
3. `auiTableScrollShadow`  更名为 `auiTableScrollable`
  在 #372 中 `auiTableScrollShadow` 继承了 `cdkScrollable` , 本次改动该指令也会修改`aui-table`的`overflow`为`auto`, 已经不仅是为滚动表格添加阴影的指令，所以修改命名
  `auiTableScrollShadow`依然作为输入属性，禁用表格滚动阴影需要显示设置为`false`