### PR TITLE
fix: scroll-table row height less than table 1px

### DIFF
--- a/.changeset/cuddly-actors-sing.md
+++ b/.changeset/cuddly-actors-sing.md
@@ -1,0 +1,5 @@
+---
+"@alauda/ui": patch
+---
+
+fix: scroll-table row height less than table 1px

--- a/src/table/table-scroll.scss
+++ b/src/table/table-scroll.scss
@@ -103,6 +103,7 @@ $stickyCssClass: 'aui-table-sticky';
     border: none;
     padding: 0;
     align-items: stretch;
+    min-height: $table-row-min-height + 1;
 
     .aui-table__cell {
       border-width: 1px 0;
@@ -121,6 +122,8 @@ $stickyCssClass: 'aui-table-sticky';
     }
 
     &:last-child {
+      min-height: $table-row-min-height + 2;
+
       .aui-table__cell {
         &:first-of-type {
           border-bottom-left-radius: use-var(border-radius-l);


### PR DESCRIPTION
`alauda-fe`里对`dialog`里的`table:min-height`设置为了`50px`,不会触发少1px的问题
因为`cell` 文本内容 20px+上下填充共30px 就达到了50px, 不管border设在`cell`上还是`row`都会正常撑开高度