### PR TITLE
feat: no track ng package debug config any more

### DIFF
--- a/ng-package.debug.json
+++ b/ng-package.debug.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "./node_modules/ng-packagr/ng-package.schema.json",
-  "dest": "${your_own_debug_project_path}/node_modules/@alauda/ui",
-  "lib": {
-    "entryFile": "./src/index.ts"
-  }
-}


### PR DESCRIPTION
https://confluence.alauda.cn/pages/viewpage.action?pageId=133083785

通过 `git update-index –assume-unchanged` 取消对 `ng-package.debug.json` 本地修改的追踪 ，虽然可以不修改远程仓库的状态
但是在远程仓库对 `ng-package.debug.json` 的修改后拉取，或本地 checkout 到其他没有该文件的分支，会导致操作失败需要额外的手动处理
所以远程仓库不再保留 `ng-package.debug.json` , 需要调试则在本地自行创建配置，`.gitignore` 会禁用对其的追踪