### PR TITLE
chore: theme pipes add types

### DIFF
--- a/.changeset/three-buses-do.md
+++ b/.changeset/three-buses-do.md
@@ -1,0 +1,5 @@
+---
+'@alauda/ui': patch
+---
+
+fix: theme pipes add types

--- a/src/theme/theme.pipe.ts
+++ b/src/theme/theme.pipe.ts
@@ -12,17 +12,17 @@ import { cssVar, rgbColor, rgbaColor } from './utils';
 
 @Pipe({ name: 'auiRgbColor', pure: true })
 export class RgbColorPipe implements PipeTransform {
-  transform = rgbColor;
+  transform: (color: string) => string = rgbColor;
 }
 
 @Pipe({ name: 'auiRgbaColor', pure: true })
 export class RgbaColorPipe implements PipeTransform {
-  transform = rgbaColor;
+  transform: ([color, opacity]: [string, number]) => string = rgbaColor;
 }
 
 @Pipe({ name: 'auiCssVar', pure: true })
 export class CssVarPipe implements PipeTransform {
-  transform = cssVar;
+  transform: (value: string) => string = cssVar;
 }
 
 @Pipe({ name: 'auiThemePicker', pure: false })


### PR DESCRIPTION
<img width="1356" alt="企业微信截图_4d5df1e4-de7e-4cd7-b5f3-8752138de126" src="https://user-images.githubusercontent.com/11643492/212002967-85db9c2d-ec24-4cd6-ae34-868ca3c751f9.png">

In some IDE like webstorm, it shows "method expression is not a function".