### PR TITLE
fix: number-input border blocked

### DIFF
--- a/.changeset/friendly-birds-smell.md
+++ b/.changeset/friendly-birds-smell.md
@@ -1,0 +1,5 @@
+---
+"@alauda/ui": patch
+---
+
+fix: number-input border blocked and input disabled text color in safari

--- a/src/input/input.component.scss
+++ b/src/input/input.component.scss
@@ -55,6 +55,7 @@
     background-color: use-rgb(n-8);
     border-color: use-rgb(n-7) !important;
     color: use-text-color(disabled);
+    -webkit-text-fill-color: use-text-color(disabled);
     cursor: not-allowed;
   }
 

--- a/src/input/number-input/number-input.component.scss
+++ b/src/input/number-input/number-input.component.scss
@@ -102,8 +102,7 @@ $block: 'aui-number-input';
   &__control {
     flex-shrink: 0;
     width: use-var(inline-height-m);
-    height: use-var(inline-height-m);
-    border: 1px solid transparent;
+    border: none;
     color: use-rgb(main-text);
     background-color: use-rgb(main-bg);
     background-clip: padding-box;
@@ -138,23 +137,13 @@ $block: 'aui-number-input';
       position: absolute;
       top: 0;
       left: -1px;
-      width: 1px;
+      width: 0;
       height: 100%;
-      background-color: use-rgb(border);
+      border-right: 1px solid use-rgb(border);
     }
 
-    &--decrease {
-      margin: -1px 0 0 -1px;
-      border-radius: use-var(border-radius-m) 0 0 use-var(border-radius-m);
-
-      &:before {
-        left: 100%;
-      }
-    }
-
-    &--increase {
-      margin: -1px -1px 0 0;
-      border-radius: 0 use-var(border-radius-m) use-var(border-radius-m) 0;
+    &--decrease:before {
+      left: 100%;
     }
 
     &--angle-up,

--- a/src/input/number-input/number-input.component.scss
+++ b/src/input/number-input/number-input.component.scss
@@ -54,6 +54,7 @@ $block: 'aui-number-input';
     border-radius: inherit;
     background-color: inherit;
     color: inherit;
+    -webkit-text-fill-color: inherit;
     cursor: inherit;
     outline: none;
   }


### PR DESCRIPTION
border 的值并不是固定的 1px, 会随着浏览器缩放改变，导致之前通过 margin 调整按钮位置的方法会覆盖外层的 border
伪元素也是，通过 width 作为 border, 会在 100% 缩放下比实际 border 要宽