### PR TITLE
fix: autocomplete init position

### DIFF
--- a/src/autocomplete/autocomplete.component.ts
+++ b/src/autocomplete/autocomplete.component.ts
@@ -22,6 +22,7 @@ import {
   switchMap,
   tap,
   withLatestFrom,
+  first,
 } from 'rxjs';
 
 import { publishRef } from '../utils';
@@ -93,6 +94,16 @@ export class AutocompleteComponent implements AfterContentInit {
         ([hasVisibleSuggestion, hasPlaceholder]) =>
           hasVisibleSuggestion || hasPlaceholder,
       ),
+      distinctUntilChanged(),
+      tap(hasContent => {
+        if (hasContent) {
+          this.directive$$.pipe(first()).subscribe(directive => {
+            window.requestAnimationFrame(() => {
+              directive.overlayRef.updatePosition();
+            });
+          });
+        }
+      }),
     );
   }
 }


### PR DESCRIPTION
修复autocomplete组件在激活选项浮层时初始位置不是最适合的问题（可能存在展示不全的情况）