### PR TITLE
fix: fix tree hierarchical relationship

### DIFF
--- a/.changeset/slow-brooms-search.md
+++ b/.changeset/slow-brooms-search.md
@@ -1,0 +1,5 @@
+---
+"@alauda/ui": patch
+---
+
+fix: fix tree hierarchical relationship

--- a/src/tree-select/tree-node.component.html
+++ b/src/tree-select/tree-node.component.html
@@ -17,8 +17,9 @@
       [icon]="'spinner'"
     ></aui-icon>
     <aui-icon
-      *ngIf="nodeData.children && !nodeData.loading"
+      *ngIf="!nodeData.loading"
       class="aui-tree-node__indicator"
+      [class.isVisible]="nodeData.children"
       margin="left"
       size="16"
       [icon]="nodeData.expanded ? 'angle_down' : 'angle_right'"

--- a/src/tree-select/tree-node.component.scss
+++ b/src/tree-select/tree-node.component.scss
@@ -66,6 +66,10 @@
   }
 
   &__indicator {
+    &:not(.isVisible) {
+      visibility: hidden;
+    }
+
     &:hover {
       color: use-rgb(primary);
     }

--- a/stories/tree-select/tree-select.component.ts
+++ b/stories/tree-select/tree-select.component.ts
@@ -119,15 +119,33 @@ export default class TreeSelectComponent {
       expandedIcon: 'folder_open',
       children: [
         {
+          label: 'c-0',
+          value: 'c-0',
+          icon: 'folder',
+          children: [
+            {
+              label: 'c-0-1',
+              value: 'c-0-1',
+              icon: 'file',
+            },
+            {
+              label: 'c-0-2',
+              value: 'c-0-2',
+              icon: 'file',
+            },
+          ],
+        },
+        {
           label: 'c-1',
           value: 'c-1',
-          icon: 'file',
+          icon: 'folder',
         },
         {
           label: 'c-2',
           value: 'c-2',
           icon: 'file',
         },
+        
       ],
     },
     {


### PR DESCRIPTION
原来的层级关系不清晰，容易选错: 比如 c、c-1、c-2 应该对齐，c-0、c-0-1、c-0-2 不应该对齐
<img width="1245" alt="image" src="https://github.com/alauda/ui/assets/18656086/031ed3e0-a0bd-41bc-972d-3e00047bcbed">
变更之后如下：
<img width="1241" alt="image" src="https://github.com/alauda/ui/assets/18656086/1f95593e-e332-45c2-8bbf-dcf55535e496">

