### PR TITLE
fix: date pick range disable

### DIFF
--- a/src/date-picker/calendar/date-picker-panel/template.html
+++ b/src/date-picker/calendar/date-picker-panel/template.html
@@ -17,6 +17,7 @@
     [weekStartDay]="weekStartDay"
     [minDate]="minDate"
     [maxDate]="maxDate"
+    [selectedTime]="selectedTime"
     [type]="type"
     [matchDates]="[selectedDate]"
     (select)="panelValueChange($event)"
@@ -30,7 +31,7 @@
 
   <ng-container *ngIf="showFooter">
     <aui-calendar-footer
-      (clear)="clear.next()"
+      (clear)="clearValue()"
       (confirm)="confirmValue()"
       [clearable]="clearable"
       [clearText]="clearText"

--- a/src/date-picker/calendar/panel/picker-panel.ts
+++ b/src/date-picker/calendar/panel/picker-panel.ts
@@ -35,6 +35,7 @@ import {
   getTypeByNavRange,
   sortDates,
 } from '../util';
+import { TimePickerModel } from 'src/time-picker';
 
 dayjs.extend(isBetween);
 
@@ -56,6 +57,9 @@ export class PickerPanelComponent implements OnChanges {
 
   @Input()
   anchor = dayjs();
+
+  @Input()
+  selectedTime: TimePickerModel;
 
   @Input()
   matchDates: Dayjs[];
@@ -85,8 +89,20 @@ export class PickerPanelComponent implements OnChanges {
 
   get disabledDateFn() {
     return composeDisabledDateFn(
-      date => this.minDate && date.isBefore(this.minDate),
-      date => this.maxDate && date.isAfter(this.maxDate),
+      date =>
+        this.minDate &&
+        date
+          .set('hour', this.selectedTime?.hour || 23)
+          .set('minute', this.selectedTime?.minute || 59)
+          .set('second', this.selectedTime?.second || 59)
+          .isBefore(this.minDate),
+      date =>
+        this.maxDate &&
+        date
+          .set('hour', this.selectedTime?.hour || 0)
+          .set('minute', this.selectedTime?.minute || 0)
+          .set('second', this.selectedTime?.second || 0)
+          .isAfter(this.maxDate),
       this.disabledDate,
     );
   }

--- a/src/time-picker/component.ts
+++ b/src/time-picker/component.ts
@@ -23,6 +23,7 @@ import {
   TimePickerModel,
   isTimePickerModel,
 } from './time-picker.type';
+import { HOUR_ITEMS, MINUTE_ITEMS, SECOND_ITEMS } from './constant';
 
 dayjs.extend(customParseFormat);
 
@@ -93,7 +94,6 @@ export class TimePickerComponent extends CommonFormControl<
   timeFormatValue = '';
 
   override writeValue(value: TimePickerDataLike) {
-    super.writeValue(value);
     if (!value) {
       return this.setValue(null);
     }
@@ -104,7 +104,9 @@ export class TimePickerComponent extends CommonFormControl<
       result = dayjs(value);
       this.submit(false, result);
     }
-    this.setValue(result);
+    const validResult = this.validResult(result);
+    this.setValue(validResult);
+    super.writeValue(validResult);
   }
 
   setValue(value: Dayjs) {
@@ -194,5 +196,45 @@ export class TimePickerComponent extends CommonFormControl<
     if (close) {
       this.closePanel();
     }
+  }
+
+  private validResult(result: Dayjs) {
+    const validHours = this.validHours();
+    result = result.set(
+      'hour',
+      validHours.includes(result.hour()) ? result.hour() : validHours[0],
+    );
+
+    const validMinutes = this.validMinutes(result.hour());
+    result = result.set(
+      'minute',
+      validMinutes.includes(result.minute())
+        ? result.minute()
+        : validMinutes[0],
+    );
+
+    const validSeconds = this.validSeconds(result.hour(), result.minute());
+    result = result.set(
+      'second',
+      validSeconds.includes(result.second())
+        ? result.second()
+        : validSeconds[0],
+    );
+    return result;
+  }
+
+  private validHours() {
+    const disabledHours = this.disableHours?.() || [];
+    return HOUR_ITEMS.filter(hour => !disabledHours.includes(hour));
+  }
+
+  private validMinutes(hour: number) {
+    const disabledMinutes = this.disableMinutes?.(hour) || [];
+    return MINUTE_ITEMS.filter(minute => !disabledMinutes.includes(minute));
+  }
+
+  private validSeconds(hour: number, minute: number) {
+    const disabledSeconds = this.disableSeconds?.(hour, minute) || [];
+    return SECOND_ITEMS.filter(second => !disabledSeconds.includes(second));
   }
 }

--- a/src/time-picker/util.ts
+++ b/src/time-picker/util.ts
@@ -1,0 +1,69 @@
+import { Dayjs } from 'dayjs';
+import { HOUR_ITEMS, MINUTE_ITEMS, SECOND_ITEMS } from './constant';
+
+function compose<T>(...fns: Array<(arg: T) => T>): (arg: T) => T {
+  return (x: T) => fns.reduceRight((acc, fn) => fn(acc), x);
+}
+
+function closestTo(num: number) {
+  return (prev: number, curr: number) =>
+    Math.abs(curr - num) < Math.abs(prev - num) ? curr : prev;
+}
+
+function validHoursFn(disableHours?: () => number[]) {
+  const disabledHours = disableHours?.() || [];
+  const validHours = HOUR_ITEMS.filter(hour => !disabledHours.includes(hour));
+  return (result: Dayjs) =>
+    result.set(
+      'hour',
+      validHours.includes(result.hour())
+        ? result.hour()
+        : validHours.reduce(closestTo(result.hour()), validHours[0]),
+    );
+}
+
+function validMinutesFn(disableMinutes?: (hour?: number) => number[]) {
+  return (result: Dayjs) => {
+    const disabledMinutes = disableMinutes?.(result.hour()) || [];
+    const validMinutes = MINUTE_ITEMS.filter(
+      minute => !disabledMinutes.includes(minute),
+    );
+    return result.set(
+      'minute',
+      validMinutes.includes(result.minute())
+        ? result.minute()
+        : validMinutes.reduce(closestTo(result.minute()), validMinutes[0]),
+    );
+  };
+}
+
+function validSecondsFn(
+  disableSeconds?: (hour?: number, minute?: number) => number[],
+) {
+  return (result: Dayjs) => {
+    const disabledSeconds =
+      disableSeconds?.(result.hour(), result.minute()) || [];
+    const validSeconds = SECOND_ITEMS.filter(
+      second => !disabledSeconds.includes(second),
+    );
+    return result.set(
+      'second',
+      validSeconds.includes(result.second())
+        ? result.second()
+        : validSeconds.reduce(closestTo(result.second()), validSeconds[0]),
+    );
+  };
+}
+
+export function validResult(disabledTimeFn: {
+  hours?: () => number[];
+  minutes?: (hour?: number) => number[];
+  seconds?: (hour?: number, minute?: number) => number[];
+}) {
+  const validResultFn = compose(
+    validSecondsFn(disabledTimeFn?.seconds),
+    validMinutesFn(disabledTimeFn?.minutes),
+    validHoursFn(disabledTimeFn?.hours),
+  );
+  return (result: Dayjs) => validResultFn(result);
+}

--- a/stories/date-picker/basic.component.ts
+++ b/stories/date-picker/basic.component.ts
@@ -13,6 +13,8 @@ import { DatePickerType } from '@alauda/ui';
       placeholder="请选择"
       [weekStartDay]="2"
       [disabled]="disabled"
+      [minDate]="minDate"
+      [maxDate]="maxDate"
       required
     ></aui-date-picker>
     <br />
@@ -27,4 +29,15 @@ export default class DatePickerBasicComponent {
   now = dayjs();
   time = dayjs().add(7, 'day');
   DatePickerType = DatePickerType;
+
+  minDate = dayjs()
+  .subtract(7, 'day')
+  .set('hour', 12)
+  .set('minute', 32)
+  .set('second', 12);
+maxDate = dayjs()
+  .add(7, 'day')
+  .set('hour', 17)
+  .set('minute', 46)
+  .set('second', 25);
 }

--- a/stories/date-picker/date-picker.mdx
+++ b/stories/date-picker/date-picker.mdx
@@ -6,6 +6,7 @@ import * as month from './month.stories';
 import * as today from './today.stories';
 import * as withTime from './with-time.stories';
 import * as year from './year.stories';
+import * as WithMaxMinDate from './with-max-min-date.stories'
 
 <Meta title="Example/DatePicker" />
 
@@ -45,6 +46,12 @@ import * as year from './year.stories';
 <Canvas
   of={year.YearPicker}
   meta={year}
+></Canvas>
+
+
+<Canvas
+  of={WithMaxMinDate.WithMaxMinDate}
+  meta={WithMaxMinDate}
 ></Canvas>
 
 ## DatePicker Inputs

--- a/stories/date-picker/with-max-min-date.component.ts
+++ b/stories/date-picker/with-max-min-date.component.ts
@@ -4,7 +4,7 @@ import dayjs from 'dayjs';
 import { DatePickerType } from '@alauda/ui';
 
 @Component({
-  selector: 'story-date-picker-basic',
+  selector: 'story-date-picker-with-max-min-date',
   template: `
     <aui-date-picker
       [type]="DatePickerType.Day"
@@ -15,6 +15,7 @@ import { DatePickerType } from '@alauda/ui';
       [disabled]="disabled"
       [minDate]="minDate"
       [maxDate]="maxDate"
+      [showTime]="true"
       required
     ></aui-date-picker>
     <br />
@@ -22,11 +23,22 @@ import { DatePickerType } from '@alauda/ui';
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export default class DatePickerBasicComponent {
+export default class DatePickerWithMaxAndMinComponent {
   @Input()
   disabled = false;
 
   now = dayjs();
   time = dayjs().add(7, 'day');
   DatePickerType = DatePickerType;
+
+  minDate = dayjs()
+  .subtract(7, 'day')
+  .set('hour', 12)
+  .set('minute', 32)
+  .set('second', 12);
+maxDate = dayjs()
+  .add(7, 'day')
+  .set('hour', 17)
+  .set('minute', 46)
+  .set('second', 25);
 }

--- a/stories/date-picker/with-max-min-date.stories.ts
+++ b/stories/date-picker/with-max-min-date.stories.ts
@@ -1,0 +1,30 @@
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { Meta, StoryObj, moduleMetadata } from '@storybook/angular';
+
+import { ButtonModule, DatePickerModule } from '@alauda/ui';
+import DatePickerWithMaxAndMinComponent from './with-max-min-date.component';
+
+const meta: Meta<DatePickerWithMaxAndMinComponent> = {
+  title: 'Example/DatePicker',
+  component: DatePickerWithMaxAndMinComponent,
+  decorators: [
+    moduleMetadata({
+      declarations: [DatePickerWithMaxAndMinComponent],
+      imports: [
+        DatePickerModule,
+        FormsModule,
+        ReactiveFormsModule,
+        ButtonModule,
+        BrowserAnimationsModule,
+      ],
+    }),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<DatePickerWithMaxAndMinComponent>;
+
+export const WithMaxMinDate: Story = {
+  name: 'Date Picker With Max and Min Date',
+};

--- a/stories/date-picker/with-time.component.ts
+++ b/stories/date-picker/with-time.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { Dayjs } from 'dayjs';
+import dayjs, { Dayjs } from 'dayjs';
 
 import { DatePickerType } from '@alauda/ui';
 
@@ -7,16 +7,30 @@ import { DatePickerType } from '@alauda/ui';
   template: `
     <aui-date-picker
       placeholder="请选择"
-      [type]="DatePickerType.Day"
       [(ngModel)]="time"
       [showTime]="true"
+      [minDate]="minDate"
+      [maxDate]="maxDate"
     ></aui-date-picker>
     <br />
     Form value: {{ time?.toDate() }}
+    <div>{{ minDate }}</div>
+    <div>{{ maxDate }}</div>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export default class DatePickerWithTimeComponent {
   time: Dayjs = null;
   DatePickerType = DatePickerType;
+
+  minDate = dayjs()
+    .subtract(7, 'day')
+    .set('hour', 12)
+    .set('minute', 32)
+    .set('second', 12);
+  maxDate = dayjs()
+    .add(7, 'day')
+    .set('hour', 17)
+    .set('minute', 46)
+    .set('second', 25);
 }


### PR DESCRIPTION
AUI 日期选择器 `minDate` 和 `maxDate` 的限制偏弱，主要还是使用函数进行限制，但大部分场景只用最大最小日期时间即可，目前这些也存在一些问题

选择日期之后会自动带出来当前时间，然后比较 minDate 和 maxDate 的时候是拿当前时间比的，所以会导致选中日期后时间选到了不正确的值