### PR TITLE
fix: position when option update

### DIFF
--- a/.changeset/clever-lamps-scream.md
+++ b/.changeset/clever-lamps-scream.md
@@ -1,0 +1,5 @@
+---
+"@alauda/ui": patch
+---
+
+fix: update overlay position when option is changed


### PR DESCRIPTION
当过滤发生改变时options也会跟着改变，如果option的文本宽度不一致，也就是下拉选择面板的宽度发生变化时，如果不更新位置，则下拉面板和输入框会显示错位，例如：
<img width="833" alt="image" src="https://github.com/alauda/ui/assets/20862002/92e4f5eb-edb5-42b5-a341-f63c46bdeae6">
