### PR TITLE
fix: autocomplete will show placeholder when sync option

### DIFF
--- a/.changeset/eighty-pugs-mix.md
+++ b/.changeset/eighty-pugs-mix.md
@@ -1,0 +1,5 @@
+---
+"@alauda/ui": patch
+---
+
+fix: autocomplete will show placeholder when sync option

--- a/src/autocomplete/autocomplete.component.ts
+++ b/src/autocomplete/autocomplete.component.ts
@@ -68,6 +68,7 @@ export class AutocompleteComponent implements AfterContentInit {
       ),
       debounceTime(0),
       startWith(this.suggestions.map(suggestion => suggestion.visible)),
+      publishRef(),
     );
     this.hasVisibleSuggestion$ = this.visibles$.pipe(
       map(visible => visible.some(Boolean)),


### PR DESCRIPTION
如果 autocomplete 的 option 是异步数据会把 placeholder 也展现出来
