### PR TITLE
fix: autocomplete circle dependencies

### DIFF
--- a/.changeset/green-planets-act.md
+++ b/.changeset/green-planets-act.md
@@ -1,0 +1,5 @@
+---
+"@alauda/ui": patch
+---
+
+fix: autocomplete circle dependencies

--- a/src/autocomplete/suggestion/suggestion.component.ts
+++ b/src/autocomplete/suggestion/suggestion.component.ts
@@ -4,9 +4,11 @@ import {
   ChangeDetectorRef,
   Component,
   ElementRef,
+  Inject,
   Input,
   ViewChild,
   ViewEncapsulation,
+  forwardRef,
 } from '@angular/core';
 import {
   BehaviorSubject,
@@ -62,6 +64,7 @@ export class SuggestionComponent {
 
   constructor(
     private readonly cdr: ChangeDetectorRef,
+    @Inject(forwardRef(() => AutocompleteComponent))
     private readonly autocomplete: AutocompleteComponent,
   ) {
     this.selected$ = combineLatest([


### PR DESCRIPTION
#526 

tags-input 在使用自动填充时似乎有问题，应该不是本次改动导致的，用 #528 跟踪