### PR TITLE
fix: form item label top margin bottom use `s`

### DIFF
--- a/.changeset/gorgeous-snakes-dance.md
+++ b/.changeset/gorgeous-snakes-dance.md
@@ -1,0 +1,5 @@
+---
+"@alauda/ui": patch
+---
+
+fix: form item label top margin bottom use s

--- a/src/form/form-item/form-item.component.scss
+++ b/src/form/form-item/form-item.component.scss
@@ -24,7 +24,7 @@ $form-item-width: (
 
     .aui-form-item__label-wrapper {
       line-height: use-var(line-height-m);
-      margin-bottom: use-var(spacing-xs);
+      margin-bottom: use-var(spacing-s);
 
       &:after {
         display: none;

--- a/src/form/form-item/form-item.component.scss
+++ b/src/form/form-item/form-item.component.scss
@@ -30,6 +30,10 @@ $form-item-width: (
         display: none;
       }
     }
+
+    .aui-form-item__label {
+      line-height: use-var(line-height-m);
+    }
   }
 
   &__label-wrapper {

--- a/src/form/form-item/form-item.component.scss
+++ b/src/form/form-item/form-item.component.scss
@@ -22,17 +22,17 @@ $form-item-width: (
   &--top {
     flex-direction: column;
 
-    .aui-form-item__label-wrapper {
-      line-height: use-var(line-height-m);
-      margin-bottom: use-var(spacing-s);
-
-      &:after {
-        display: none;
-      }
-    }
-
     .aui-form-item__label {
       line-height: use-var(line-height-m);
+
+      &-wrapper {
+        line-height: use-var(line-height-m);
+        margin-bottom: use-var(spacing-s);
+
+        &:after {
+          display: none;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
按照设计稿 top-position 的 label 下边距为 4px 

![image](https://github.com/alauda/ui/assets/24679861/5a8291bb-14f6-4214-8d08-35f537d3e906)
