### PR TITLE
fix: known drawer issues

### DIFF
--- a/.changeset/neat-pots-doubt.md
+++ b/.changeset/neat-pots-doubt.md
@@ -1,0 +1,6 @@
+---
+'@alauda/ui': patch
+---
+
+- fix: no default config for using service mode     
+- fix: not auto destroy when hiding for using service mode  

--- a/src/drawer/component/drawer.component.ts
+++ b/src/drawer/component/drawer.component.ts
@@ -42,7 +42,7 @@ export class DrawerComponent<
   footer: string | TemplateRef<C>;
 
   @Input()
-  size: DrawerSize = DrawerSize.Medium;
+  size: DrawerSize;
 
   @Input()
   offsetY = '0px';
@@ -54,10 +54,10 @@ export class DrawerComponent<
   content: TemplateRef<C> | ComponentType<T>;
 
   @Input()
-  hideOnClickOutside = false;
+  hideOnClickOutside: boolean;
 
   @Input()
-  showClose = true;
+  showClose: boolean;
 
   @Input()
   drawerClass: string;
@@ -69,7 +69,7 @@ export class DrawerComponent<
   maskClosable: boolean;
 
   @Input()
-  divider = true;
+  divider: boolean;
 
   @Input()
   width: number;

--- a/src/drawer/component/drawer.component.ts
+++ b/src/drawer/component/drawer.component.ts
@@ -45,7 +45,7 @@ export class DrawerComponent<
   size: DrawerSize;
 
   @Input()
-  offsetY = '0px';
+  offsetY: string;
 
   @Input()
   visible: boolean;
@@ -76,6 +76,9 @@ export class DrawerComponent<
 
   @Input()
   contentParams: C;
+
+  @Input()
+  disposeWhenHide = false;
 
   @Output()
   readonly close = new EventEmitter<R>();

--- a/src/drawer/drawer.service.ts
+++ b/src/drawer/drawer.service.ts
@@ -8,12 +8,13 @@ import { DrawerRef } from './drawer-ref';
 import { DrawerOptions, DrawerSize } from './types';
 
 const DRAWER_OVERLAY_CLASS = 'aui-drawer-overlay';
-const defaultOptions: DrawerOptions = {
+const DEFAULT_OPTIONS: DrawerOptions = {
   size: DrawerSize.Medium,
-  offsetY: '0px',
+  offsetY: '0',
   showClose: true,
-  hideOnClickOutside: true,
+  hideOnClickOutside: false,
   divider: true,
+  disposeWhenHide: true,
 };
 
 @Injectable()
@@ -46,7 +47,7 @@ export class DrawerService<
 
   updateOptions(options: DrawerOptions<T, C>): void {
     this.options = {
-      ...(defaultOptions as DrawerOptions<T, C>),
+      ...(DEFAULT_OPTIONS as DrawerOptions<T, C>),
       ...options,
     };
   }
@@ -103,6 +104,7 @@ export class DrawerService<
     drawerInternalComponentRef.instance.animationStep$.subscribe(step => {
       if (step === 'hideDone') {
         this.invisible$.next();
+        this.options.disposeWhenHide && this.dispose();
         this.overlayRef?.getConfig().scrollStrategy.disable();
       }
     });
@@ -119,12 +121,17 @@ export class DrawerService<
     });
   }
 
-  ngOnDestroy(): void {
-    this.invisible$.next();
+  private dispose() {
     if (this.overlayRef) {
       this.overlayRef.getConfig().scrollStrategy.disable();
       this.overlayRef.dispose();
       this.overlayRef = null;
     }
+    this.drawerInternalComponentRef = null;
+  }
+
+  ngOnDestroy(): void {
+    this.invisible$.next();
+    this.dispose();
   }
 }

--- a/src/drawer/drawer.service.ts
+++ b/src/drawer/drawer.service.ts
@@ -5,9 +5,16 @@ import { debounceTime, filter, fromEvent, Subject, takeUntil } from 'rxjs';
 
 import { DrawerInternalComponent } from './component/internal/internal.component';
 import { DrawerRef } from './drawer-ref';
-import { DrawerOptions } from './types';
+import { DrawerOptions, DrawerSize } from './types';
 
 const DRAWER_OVERLAY_CLASS = 'aui-drawer-overlay';
+const defaultOptions: DrawerOptions = {
+  size: DrawerSize.Medium,
+  offsetY: '0px',
+  showClose: true,
+  hideOnClickOutside: true,
+  divider: true,
+};
 
 @Injectable()
 export class DrawerService<
@@ -38,7 +45,10 @@ export class DrawerService<
   }
 
   updateOptions(options: DrawerOptions<T, C>): void {
-    this.options = options;
+    this.options = {
+      ...(defaultOptions as DrawerOptions<T, C>),
+      ...options,
+    };
   }
 
   private createOverlay() {

--- a/src/drawer/types.ts
+++ b/src/drawer/types.ts
@@ -26,4 +26,5 @@ export interface DrawerOptions<T = unknown, C extends object = object> {
   mask?: boolean;
   maskClosable?: boolean; // 点击背景是否关闭抽屉
   hideOnClickOutside?: boolean; // 在抽屉外点击是否关闭抽屉，与 maskClosable 的区别是是否有 mask
+  disposeWhenHide?: boolean; // 抽屉不可见时是否销毁，使用组件方式时默认为false
 }


### PR DESCRIPTION
1. 使用服务方式不会应用组件设定的默认值
    a. 之前是使用 Object.assign(compnent, option)，现在变成服务是唯一打开抽屉方式，组件只是服务的另一个形式，顺序颠倒了，是先组件后服务。所以应该把默认值写到service里，把组件的assign给服务
2. 使用服务的方式关闭后再打开内容还是之前的，不会变，哪怕数据变了
    a. 因为之前使用服务的方式关闭会销毁实例，而组件形式因为有两个overlay，销毁的只是服务的overlay，所以aui-drawer组件本身的overlay并没有被销毁，也就是传入的组件并没有被销毁；
    b. 之前两种形式的这种差异没有被清晰的意识到，然后受家忍提出“需要缓存”的影响，就改成关闭不销毁了，包括使用服务的方式。后面在验证的时候也只是验证表单状态是否被保留，而没有验证是否可以正常更新内容导致出现问题
    c. 新增 disposeWhenHide 配置，默认值是true，也就是关闭即销毁，但组件里默认是false，与之前的行为保持一致