### PR TITLE
fix: drawer click outside event should not stopPropagation

### DIFF
--- a/src/drawer/drawer.service.ts
+++ b/src/drawer/drawer.service.ts
@@ -67,7 +67,6 @@ export class DrawerService<
           event.target instanceof Node &&
           !this.overlayRef.hostElement?.parentNode?.contains(event.target)
         ) {
-          event.stopPropagation();
           event.preventDefault();
           this.drawerRef.close();
         }


### PR DESCRIPTION
stopPropagation 会导致触发 hideOnClickOutside 的同时，外界的 click 事件失效