### PR TITLE
fix: tab header paginator not show without viewport resize

### DIFF
--- a/.changeset/small-sheep-train.md
+++ b/.changeset/small-sheep-train.md
@@ -1,0 +1,5 @@
+---
+"@alauda/ui": patch
+---
+
+fix: tab header paginator not show without viewport resize

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -22,3 +22,9 @@ Object.defineProperty(window, 'matchMedia', {
     dispatchEvent: jest.fn(),
   })),
 });
+
+global.ResizeObserver = jest.fn().mockImplementation(() => ({
+  observe: jest.fn(),
+  unobserve: jest.fn(),
+  disconnect: jest.fn(),
+}));

--- a/src/tabs/tab-header.component.ts
+++ b/src/tabs/tab-header.component.ts
@@ -19,7 +19,7 @@ import {
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
-import { Subject, debounceTime, takeUntil } from 'rxjs';
+import { Subject, debounceTime, merge, takeUntil } from 'rxjs';
 
 import { IconComponent } from '../icon/icon.component';
 import { Bem, buildBem, observeResizeOn } from '../internal/utils';
@@ -195,13 +195,13 @@ export class TabHeaderComponent
       .withWrap();
     this._keyManager.updateActiveItem(0);
 
-    // Defer the first call in order to allow for slower browsers to lay out the elements.
-    // This helps in cases where the user lands directly on a page with paginated tabs.
-    requestAnimationFrame(realign);
-
     // On tab list resize, realign the ink bar and update the orientation of
     // the key manager if the direction has changed.
-    observeResizeOn(this._tabList.nativeElement)
+    merge(
+      observeResizeOn(this._tabList.nativeElement),
+      observeResizeOn(this._tabListContainer.nativeElement),
+      observeResizeOn(this._paginationWrapper.nativeElement),
+    )
       .pipe(debounceTime(100), takeUntil(this._destroyed))
       .subscribe(realign);
 


### PR DESCRIPTION
在首次渲染的时候, tablist 的尺寸需要 paginator 时不会显示 paginator , 原因是 tablist 变更时 dom 尺寸还未变化, 导致计算值不正确  
目前的实现只监听 viewport 的尺寸变化

处理是使用 ResizeObservable 监听 tablist 的 dom 尺寸变化, 跟 window.resize 同样触发 realign  
不再关注 tabLabelCount 的变化来更新 paginator 显示