### PR TITLE
style: date picker panel row main axis between

### DIFF
--- a/.changeset/itchy-planets-brush.md
+++ b/.changeset/itchy-planets-brush.md
@@ -1,0 +1,5 @@
+---
+"@alauda/ui": patch
+---
+
+style: date picker panel row main axis between

--- a/src/date-picker/calendar/header/style.scss
+++ b/src/date-picker/calendar/header/style.scss
@@ -13,23 +13,35 @@ $block: aui-calendar-header;
   &__nav-content {
     flex: 1;
     display: flex;
+    flex-wrap: wrap;
     justify-content: center;
     align-items: center;
     font-size: use-var(font-size-l);
     color: use-text-color(main);
     font-weight: use-var(font-weight-bolder);
 
-    a {
+    .separator {
+      margin: 0 use-var(spacing-s);
+    }
+
+    .aui-button--text {
       color: use-text-color(main);
 
+      .aui-button__content {
+        font-size: use-var(font-size-l);
+        font-weight: use-var(font-weight-bolder);
+        padding: 0;
+      }
+
       &:hover {
+        background-color: transparent;
         color: use-rgb(primary);
         text-decoration: none !important;
       }
-    }
 
-    a + a {
-      margin-left: 5px;
+      + .aui-button--text {
+        margin-left: 0;
+      }
     }
   }
 }

--- a/src/date-picker/calendar/header/template.html
+++ b/src/date-picker/calendar/header/template.html
@@ -17,30 +17,35 @@
     *ngIf="dateNavRange === DateNavRange.Month"
     [class]="bem.element('nav-content')"
   >
-    <a
-      href="javascript:;"
+    <button
+      aui-button="text"
       (click)="clickNav(DateNavRange.Year)"
     >
       {{ headerRange?.start?.year() }}{{ 'year_suffix' | auiI18n }}
-    </a>
-    <a
-      href="javascript:;"
+    </button>
+    <div class="separator">
+      <span *ngIf="!('year_suffix' | auiI18n) && !('month_suffix' | auiI18n)">
+        /
+      </span>
+    </div>
+    <button
+      aui-button="text"
       (click)="clickNav(DateNavRange.Month)"
     >
       {{ headerRange?.start?.month() + 1 }}{{ 'month_suffix' | auiI18n }}
-    </a>
+    </button>
   </span>
 
   <span
     *ngIf="dateNavRange === DateNavRange.Year"
     [class]="bem.element('nav-content')"
   >
-    <a
-      href="javascript:;"
+    <button
+      aui-button="text"
       (click)="clickNav(DateNavRange.Year)"
     >
       {{ headerRange?.start?.year() }}{{ 'year_suffix' | auiI18n }}
-    </a>
+    </button>
   </span>
 
   <span

--- a/src/date-picker/calendar/panel/picker-panel.style.scss
+++ b/src/date-picker/calendar/panel/picker-panel.style.scss
@@ -61,6 +61,7 @@ $left-mask-shadow: -12px 0 0 0 use-rgb(popper-bg);
     flex: 1;
     display: flex;
     align-items: center;
+    justify-content: space-between;
     @include text-set(m);
 
     width: 100%;


### PR DESCRIPTION
1. 增加了基本 date-picker-panel header 区 年月 之间的分隔符, 通过一个 div.separator 的 margin: 0 use-var(spacing-s) 填充, 当 年和月 都不存在 suffix 的时候, div 内部会显示一个 /
    > 之所以使用 div.separator 去填充间隙而不是通过翻译文本自己设置分隔符, 是因为这样做 分隔符文本 也会被当成按钮的一部分显示 hover 样式以及响应点击事件  

<img src="https://github.com/alauda/ui/assets/24679861/6ff52912-22b4-45f8-b838-4293e8038563" width="240px" />
<img src="https://github.com/alauda/ui/assets/24679861/d387fd86-37c7-45bb-ba50-011eb434698b" width="240px" />
<img src="https://github.com/alauda/ui/assets/24679861/8a136e8b-9399-4424-b749-76e35b68b439" width="240px" />

2. 原本的充当按钮作用的 \<a\> 替换为正常的 button[aui-button="text"], 并且 header 区增加 flex-wrap: warp
    > 使用 button 后  年/月 区块内部不会单独折行(符合预期),而是整行去折.但是仍会有单个区块过长的溢出问题,  要处理的话就要取消 tooltip-info 的 max-width: 400px , 但是大部分场景应该不需要

<img src="https://github.com/alauda/ui/assets/24679861/71c8c51f-339e-4fd2-91a2-4ee4c34fc0fc" width="240px" />
<img src="https://github.com/alauda/ui/assets/24679861/768a11ec-6c41-4591-bf83-6b4b57bf37e4" width="240px" />
<img src="https://github.com/alauda/ui/assets/24679861/c5cb7433-4083-4641-8908-754c5fd3da0d" width="240px" />

TODO:
1. 不同语言地区的 年月 顺序不同，可以参照 antd 使用的 rc-picker 的实现
    ``` javascript
    const monthYearNodes = locale.monthBeforeYear ? [monthNode, yearNode] : [yearNode, monthNode];
    ```
2. aui-range-picker 也会遇到类似 header 过长的溢出问题，需要之后一起解决
