### PR TITLE
Feat/date picker panel header locale

### DIFF
--- a/.changeset/wicked-comics-return.md
+++ b/.changeset/wicked-comics-return.md
@@ -1,0 +1,5 @@
+---
+"@alauda/ui": patch
+---
+
+Feat/date picker panel header locale

--- a/.storybook/global.scss
+++ b/.storybook/global.scss
@@ -1,0 +1,2 @@
+@import './reset-browser';
+@import '../src/theme/style.scss';

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -3,6 +3,8 @@ import { addons } from '@storybook/addons';
 import type { Preview } from '@storybook/angular';
 
 import docJson from '../documentation.json';
+// eslint-disable-next-line import/no-webpack-loader-syntax, import/no-unresolved
+import '!style-loader!css-loader!sass-loader!./global.scss';
 
 setCompodocJson(docJson);
 

--- a/.storybook/reset-browser.scss
+++ b/.storybook/reset-browser.scss
@@ -1,0 +1,92 @@
+@import '../src/theme/var';
+@import '../src/theme/mixin';
+
+* {
+  &,
+  &:before,
+  &:after {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    font: inherit;
+    box-sizing: border-box;
+    vertical-align: baseline;
+  }
+
+  &:focus {
+    outline: none;
+  }
+}
+
+em {
+  font-style: italic;
+}
+
+ol {
+  list-style: decimal;
+  margin-left: 16px;
+}
+
+ul {
+  list-style: none;
+}
+
+blockquote,
+q {
+  quotes: none;
+
+  &:before,
+  &:after {
+    content: '';
+    content: none;
+  }
+}
+
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+body {
+  -webkit-font-smoothing: auto;
+  -moz-osx-font-smoothing: auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 100%;
+  min-height: 100%;
+  color: use-text-color(main);
+  background-color: use-rgb(main-bg);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC',
+    Arial, 'Microsoft YaHei', sans-serif;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1.43;
+}
+
+pre,
+code {
+  font-family: Menlo, Monaco, 'Courier New', monospace;
+  white-space: pre-wrap;
+  font-size: 14px;
+  line-height: 20px;
+  padding: 12px;
+  background: use-rgb(n-9);
+  border-radius: 2px;
+
+  &[ngCodeColorize] {
+    padding: 0 12px;
+  }
+}
+
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus,
+input:-webkit-autofill:active {
+  -webkit-text-fill-color: #{use-text-color(main)} !important;
+  box-shadow: 0 0 0 3000px #{use-rgb(main-bg)} inset !important;
+}
+
+[hidden] {
+  display: none !important;
+}

--- a/.storybook/reset-browser.scss
+++ b/.storybook/reset-browser.scss
@@ -56,7 +56,7 @@ body {
   min-width: 100%;
   min-height: 100%;
   color: use-text-color(main);
-  background-color: use-rgb(main-bg);
+  background-color: use-rgb(n-10);
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC',
     Arial, 'Microsoft YaHei', sans-serif;
   font-size: 14px;

--- a/angular.json
+++ b/angular.json
@@ -76,6 +76,7 @@
             "compodoc": true,
             "compodocArgs": ["-e", "json", "-d", "."],
             "outputDir": "dist",
+            "styles": [".storybook/global.scss"],
             "enableProdMode": false // FIXME: https://github.com/storybookjs/storybook/issues/23534
           }
         }

--- a/angular.json
+++ b/angular.json
@@ -64,7 +64,8 @@
             "browserTarget": "storybook:build",
             "compodoc": true,
             "compodocArgs": ["-e", "json", "-d", "."],
-            "port": 6006
+            "port": 6006,
+            "styles": [".storybook/global.scss"]
           }
         },
         "build-storybook": {

--- a/angular.json
+++ b/angular.json
@@ -64,8 +64,7 @@
             "browserTarget": "storybook:build",
             "compodoc": true,
             "compodocArgs": ["-e", "json", "-d", "."],
-            "port": 6006,
-            "styles": [".storybook/global.scss"]
+            "port": 6006
           }
         },
         "build-storybook": {
@@ -76,7 +75,6 @@
             "compodoc": true,
             "compodocArgs": ["-e", "json", "-d", "."],
             "outputDir": "dist",
-            "styles": [".storybook/global.scss"],
             "enableProdMode": false // FIXME: https://github.com/storybookjs/storybook/issues/23534
           }
         }

--- a/src/date-picker/calendar/header/component.ts
+++ b/src/date-picker/calendar/header/component.ts
@@ -8,7 +8,6 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 import dayjs, { ConfigType, Dayjs } from 'dayjs';
-import { map, startWith } from 'rxjs';
 
 import { ButtonComponent } from '../../../button/button.component';
 import { I18nPipe, I18nService } from '../../../i18n';
@@ -19,7 +18,7 @@ import {
   DateNavRange,
   Side,
 } from '../../date-picker.type';
-import { DatePickerType, MONTH, YEAR } from '../constant';
+import { MONTH, YEAR } from '../constant';
 import { calcRangeValue } from '../util';
 
 const bem = buildBem('aui-calendar-header');
@@ -75,17 +74,7 @@ export class CalendarHeaderComponent {
 
   DateNavRange = DateNavRange;
 
-  monthBeforeYear$ = this.i18nService.localeChange$.pipe(
-    map(locale => {
-      const parts = new Intl.DateTimeFormat(locale).formatToParts(new Date());
-      return (
-        parts.findIndex(part => part.type === DatePickerType.Month) <
-        parts.findIndex(part => part.type === DatePickerType.Year)
-      );
-    }),
-    startWith(false),
-    publishRef(),
-  );
+  monthBeforeYear$ = this.i18nService.monthBeforeYear$.pipe(publishRef());
 
   constructor(private readonly i18nService: I18nService) {}
 

--- a/src/date-picker/calendar/header/component.ts
+++ b/src/date-picker/calendar/header/component.ts
@@ -1,4 +1,4 @@
-import { AsyncPipe, NgIf, NgTemplateOutlet } from '@angular/common';
+import { NgIf, NgTemplateOutlet } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -6,18 +6,16 @@ import {
   Input,
   Output,
   ViewEncapsulation,
+  computed,
+  signal,
 } from '@angular/core';
 import dayjs, { ConfigType, Dayjs } from 'dayjs';
 
 import { ButtonComponent } from '../../../button/button.component';
 import { I18nPipe, I18nService } from '../../../i18n';
 import { IconComponent } from '../../../icon/icon.component';
-import { buildBem, publishRef } from '../../../internal/utils';
-import {
-  CalendarHeaderRange,
-  DateNavRange,
-  Side,
-} from '../../date-picker.type';
+import { buildBem } from '../../../internal/utils';
+import { DateNavRange, Side } from '../../date-picker.type';
 import { MONTH, YEAR } from '../constant';
 import { calcRangeValue } from '../util';
 
@@ -30,21 +28,32 @@ const bem = buildBem('aui-calendar-header');
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
-  imports: [
-    NgIf,
-    NgTemplateOutlet,
-    ButtonComponent,
-    IconComponent,
-    I18nPipe,
-    AsyncPipe,
-  ],
+  imports: [NgIf, NgTemplateOutlet, ButtonComponent, IconComponent, I18nPipe],
 })
 export class CalendarHeaderComponent {
   @Input()
-  dateNavRange = DateNavRange.Month;
+  get dateNavRange() {
+    return this.$$dateNavRange();
+  }
+
+  set dateNavRange(val) {
+    if (!val || this.$$dateNavRange() === val) {
+      return;
+    }
+    this.$$dateNavRange.set(val);
+  }
 
   @Input()
-  anchor = dayjs();
+  get anchor() {
+    return this.$$anchor();
+  }
+
+  set anchor(val) {
+    if (!val || this.$$anchor() === val) {
+      return;
+    }
+    this.$$anchor.set(val);
+  }
 
   @Input()
   maxAvail?: ConfigType;
@@ -66,15 +75,32 @@ export class CalendarHeaderComponent {
   @Output()
   anchorChange = new EventEmitter<Dayjs>();
 
-  get headerRange(): CalendarHeaderRange {
-    return calcRangeValue(this.dateNavRange, this.anchor);
-  }
+  private readonly $$dateNavRange = signal(DateNavRange.Month);
+  private readonly $$anchor = signal(dayjs());
 
   bem = bem;
 
   DateNavRange = DateNavRange;
 
-  monthBeforeYear$ = this.i18nService.monthBeforeYear$.pipe(publishRef());
+  $monthBeforeYear = this.i18nService.$monthBeforeYear;
+
+  $headerRange = computed(() => {
+    const locale = this.i18nService.$locale();
+    const [start, end] = Object.values(
+      calcRangeValue(this.$$dateNavRange(), this.$$anchor()),
+    ).map(date => date.toDate());
+
+    return {
+      start: {
+        year: start.toLocaleDateString(locale, { year: 'numeric' }),
+        month: start.toLocaleDateString(locale, { month: 'short' }),
+      },
+      end: {
+        year: end?.toLocaleDateString(locale, { year: 'numeric' }),
+        month: end?.toLocaleDateString(locale, { month: 'short' }),
+      },
+    };
+  });
 
   constructor(private readonly i18nService: I18nService) {}
 

--- a/src/date-picker/calendar/header/component.ts
+++ b/src/date-picker/calendar/header/component.ts
@@ -11,7 +11,7 @@ import dayjs, { ConfigType, Dayjs } from 'dayjs';
 import { map, startWith } from 'rxjs';
 
 import { ButtonComponent } from '../../../button/button.component';
-import { I18nPipe } from '../../../i18n/i18n.pipe';
+import { I18nPipe, I18nService } from '../../../i18n';
 import { IconComponent } from '../../../icon/icon.component';
 import { buildBem, publishRef } from '../../../internal/utils';
 import {
@@ -21,8 +21,6 @@ import {
 } from '../../date-picker.type';
 import { DatePickerType, MONTH, YEAR } from '../constant';
 import { calcRangeValue } from '../util';
-
-import { I18nService } from 'src/i18n';
 
 const bem = buildBem('aui-calendar-header');
 

--- a/src/date-picker/calendar/header/style.scss
+++ b/src/date-picker/calendar/header/style.scss
@@ -3,7 +3,7 @@
 $block: aui-calendar-header;
 
 $aui-text-button-mini-width: use-var(inline-height-xs);
-$aui-text-button-mini-spacing: 2px;
+$aui-text-button-mini-spacing: use-var(spacing-s);
 
 .#{$block} {
   &__container {

--- a/src/date-picker/calendar/header/style.scss
+++ b/src/date-picker/calendar/header/style.scss
@@ -2,6 +2,7 @@
 
 $block: aui-calendar-header;
 $prev-next-icon-button-width: 24px;
+$prev-next-icon-button-spacing: 2px;
 
 .#{$block} {
   &__container {
@@ -13,7 +14,10 @@ $prev-next-icon-button-width: 24px;
 
   &__nav-content {
     flex: 1;
-    max-width: calc(100% - $prev-next-icon-button-width * 4);
+    max-width: calc(
+      100% - $prev-next-icon-button-width * 4 - $prev-next-icon-button-spacing *
+        2
+    );
     display: flex;
     flex-wrap: wrap;
     justify-content: center;

--- a/src/date-picker/calendar/header/style.scss
+++ b/src/date-picker/calendar/header/style.scss
@@ -1,6 +1,7 @@
 @import '../../../theme/var';
 
 $block: aui-calendar-header;
+$prev-next-icon-button-width: 24px;
 
 .#{$block} {
   &__container {
@@ -12,6 +13,7 @@ $block: aui-calendar-header;
 
   &__nav-content {
     flex: 1;
+    max-width: calc(100% - $prev-next-icon-button-width * 4);
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
@@ -42,6 +44,10 @@ $block: aui-calendar-header;
       + .aui-button--text {
         margin-left: 0;
       }
+    }
+
+    .aui-button--text.header-range {
+      max-width: 100%;
     }
   }
 }

--- a/src/date-picker/calendar/header/style.scss
+++ b/src/date-picker/calendar/header/style.scss
@@ -1,8 +1,9 @@
 @import '../../../theme/var';
 
 $block: aui-calendar-header;
-$prev-next-icon-button-width: 24px;
-$prev-next-icon-button-spacing: 2px;
+
+$aui-text-button-mini-width: use-var(inline-height-xs);
+$aui-text-button-mini-spacing: 2px;
 
 .#{$block} {
   &__container {
@@ -15,8 +16,7 @@ $prev-next-icon-button-spacing: 2px;
   &__nav-content {
     flex: 1;
     max-width: calc(
-      100% - $prev-next-icon-button-width * 4 - $prev-next-icon-button-spacing *
-        2
+      100% - $aui-text-button-mini-width * 4 - $aui-text-button-mini-spacing * 2
     );
     display: flex;
     flex-wrap: wrap;

--- a/src/date-picker/calendar/header/template.html
+++ b/src/date-picker/calendar/header/template.html
@@ -17,23 +17,21 @@
     *ngIf="dateNavRange === DateNavRange.Month"
     [class]="bem.element('nav-content')"
   >
-    <button
-      aui-button="text"
-      (click)="clickNav(DateNavRange.Year)"
-    >
-      {{ headerRange?.start?.year() }}{{ 'year_suffix' | auiI18n }}
-    </button>
+    <ng-container
+      [ngTemplateOutlet]="
+        (monthBeforeYear$ | async) ? monthTemplate : yearTemplate
+      "
+    ></ng-container>
     <div class="separator">
       <span *ngIf="!('year_suffix' | auiI18n) && !('month_suffix' | auiI18n)">
         /
       </span>
     </div>
-    <button
-      aui-button="text"
-      (click)="clickNav(DateNavRange.Month)"
-    >
-      {{ headerRange?.start?.month() + 1 }}{{ 'month_suffix' | auiI18n }}
-    </button>
+    <ng-container
+      [ngTemplateOutlet]="
+        (monthBeforeYear$ | async) ? yearTemplate : monthTemplate
+      "
+    ></ng-container>
   </span>
 
   <span
@@ -121,5 +119,22 @@
     <aui-icon
       [icon]="side === 'left' ? 'angles_left' : 'angles_right'"
     ></aui-icon>
+  </button>
+</ng-template>
+
+<ng-template #yearTemplate>
+  <button
+    aui-button="text"
+    (click)="clickNav(DateNavRange.Year)"
+  >
+    {{ headerRange?.start?.year() }}{{ 'year_suffix' | auiI18n }}
+  </button>
+</ng-template>
+<ng-template #monthTemplate>
+  <button
+    aui-button="text"
+    (click)="clickNav(DateNavRange.Month)"
+  >
+    {{ headerRange?.start?.month() + 1 }}{{ 'month_suffix' | auiI18n }}
   </button>
 </ng-template>

--- a/src/date-picker/calendar/header/template.html
+++ b/src/date-picker/calendar/header/template.html
@@ -125,6 +125,8 @@
 <ng-template #yearTemplate>
   <button
     aui-button="text"
+    class="header-range"
+    [title]="headerRange?.start?.year() + ('year_suffix' | auiI18n)"
     (click)="clickNav(DateNavRange.Year)"
   >
     {{ headerRange?.start?.year() }}{{ 'year_suffix' | auiI18n }}
@@ -133,6 +135,8 @@
 <ng-template #monthTemplate>
   <button
     aui-button="text"
+    class="header-range"
+    [title]="headerRange?.start?.month() + 1 + ('month_suffix' | auiI18n)"
     (click)="clickNav(DateNavRange.Month)"
   >
     {{ headerRange?.start?.month() + 1 }}{{ 'month_suffix' | auiI18n }}

--- a/src/date-picker/calendar/header/template.html
+++ b/src/date-picker/calendar/header/template.html
@@ -126,7 +126,6 @@
   <button
     aui-button="text"
     class="header-range"
-    [title]="headerRange?.start?.year() + ('year_suffix' | auiI18n)"
     (click)="clickNav(DateNavRange.Year)"
   >
     {{ headerRange?.start?.year() }}{{ 'year_suffix' | auiI18n }}
@@ -136,7 +135,6 @@
   <button
     aui-button="text"
     class="header-range"
-    [title]="headerRange?.start?.month() + 1 + ('month_suffix' | auiI18n)"
     (click)="clickNav(DateNavRange.Month)"
   >
     {{ headerRange?.start?.month() + 1 }}{{ 'month_suffix' | auiI18n }}

--- a/src/date-picker/calendar/header/template.html
+++ b/src/date-picker/calendar/header/template.html
@@ -18,19 +18,11 @@
     [class]="bem.element('nav-content')"
   >
     <ng-container
-      [ngTemplateOutlet]="
-        (monthBeforeYear$ | async) ? monthTemplate : yearTemplate
-      "
+      [ngTemplateOutlet]="$monthBeforeYear() ? monthTemplate : yearTemplate"
     ></ng-container>
-    <div class="separator">
-      <span *ngIf="!('year_suffix' | auiI18n) && !('month_suffix' | auiI18n)">
-        /
-      </span>
-    </div>
+    <div class="separator"></div>
     <ng-container
-      [ngTemplateOutlet]="
-        (monthBeforeYear$ | async) ? yearTemplate : monthTemplate
-      "
+      [ngTemplateOutlet]="$monthBeforeYear() ? yearTemplate : monthTemplate"
     ></ng-container>
   </span>
 
@@ -42,7 +34,7 @@
       aui-button="text"
       (click)="clickNav(DateNavRange.Year)"
     >
-      {{ headerRange?.start?.year() }}{{ 'year_suffix' | auiI18n }}
+      {{ $headerRange().start.year }}
     </button>
   </span>
 
@@ -50,7 +42,7 @@
     *ngIf="dateNavRange === DateNavRange.Decade"
     [class]="bem.element('nav-content')"
   >
-    {{ headerRange?.start.year() }} - {{ headerRange?.end?.year() }}
+    {{ $headerRange().start.year }} - {{ $headerRange().end.year }}
   </span>
 
   <div [class]="bem.element('nav-action')">
@@ -75,6 +67,8 @@
   <span class="action-bar">
     <button
       aui-button="text"
+      size="mini"
+      [square]="true"
       *ngIf="side === 'right'"
       [class.hidden]="
         !shouldShowNav(DateNavRange.Month, side) ||
@@ -86,6 +80,8 @@
     </button>
     <button
       aui-button="text"
+      size="mini"
+      [square]="true"
       (click)="navHead(DateNavRange.Year, side === 'left' ? -1 : 1)"
       [class.hidden]="!shouldShowNav(DateNavRange.Year, side)"
     >
@@ -95,6 +91,8 @@
     </button>
     <button
       aui-button="text"
+      size="mini"
+      [square]="true"
       *ngIf="side === 'left'"
       [class.hidden]="
         !shouldShowNav(DateNavRange.Month, side) ||
@@ -113,6 +111,8 @@
 >
   <button
     aui-button="text"
+    size="mini"
+    [square]="true"
     (click)="navHead(DateNavRange.Decade, side === 'left' ? -10 : 10)"
     [class.hidden]="!shouldShowNav(DateNavRange.Decade, side)"
   >
@@ -128,7 +128,7 @@
     class="header-range"
     (click)="clickNav(DateNavRange.Year)"
   >
-    {{ headerRange?.start?.year() }}{{ 'year_suffix' | auiI18n }}
+    {{ $headerRange().start.year }}
   </button>
 </ng-template>
 <ng-template #monthTemplate>
@@ -137,6 +137,6 @@
     class="header-range"
     (click)="clickNav(DateNavRange.Month)"
   >
-    {{ headerRange?.start?.month() + 1 }}{{ 'month_suffix' | auiI18n }}
+    {{ $headerRange().start.month }}
   </button>
 </ng-template>

--- a/src/date-picker/calendar/range-picker-panel/style.scss
+++ b/src/date-picker/calendar/range-picker-panel/style.scss
@@ -41,6 +41,7 @@ $block: aui-date-range-picker-panel;
 
     aui-calendar-header {
       flex: 0 0 $range-picker-header-width;
+      max-width: 50%;
     }
   }
 

--- a/src/date-picker/date-picker/date-picker.component.ts
+++ b/src/date-picker/date-picker/date-picker.component.ts
@@ -3,7 +3,6 @@ import {
   Component,
   EventEmitter,
   Input,
-  OnInit,
   Output,
   TemplateRef,
   ViewEncapsulation,
@@ -41,10 +40,7 @@ import { DatePickerTriggerComponent } from '../trigger/trigger.component';
     FormsModule,
   ],
 })
-export class DatePickerComponent
-  extends CommonFormControl<ConfigType, Dayjs>
-  implements OnInit
-{
+export class DatePickerComponent extends CommonFormControl<ConfigType, Dayjs> {
   @Input()
   clearable = true;
 
@@ -96,13 +92,6 @@ export class DatePickerComponent
   value: Dayjs;
   DatePickerType = DatePickerType;
 
-  ngOnInit() {
-    if (!this.format) {
-      this.format = this.getDefaultFormat(this.type);
-      this.cdr.markForCheck();
-    }
-  }
-
   override valueIn(obj: ConfigType) {
     return obj ? dayjs(obj) : null;
   }
@@ -111,16 +100,6 @@ export class DatePickerComponent
     super.writeValue(obj);
     this.value = obj;
     this.cdr.markForCheck();
-  }
-
-  private getDefaultFormat(type = DatePickerType.Day) {
-    return type === DatePickerType.Year
-      ? 'YYYY'
-      : type === DatePickerType.Month
-      ? 'YYYY-MM'
-      : this.showTime
-      ? 'YYYY-MM-DD HH:mm:ss'
-      : 'YYYY-MM-DD';
   }
 
   clearValue() {

--- a/src/date-picker/date-picker/date-picker.template.html
+++ b/src/date-picker/date-picker/date-picker.template.html
@@ -21,7 +21,7 @@
 <ng-template #template>
   <aui-date-picker-panel
     [type]="type"
-    style="padding-top: 9px; display: inline-block"
+    style="padding-top: 9px; display: inline-block; max-width: 100%"
     [(ngModel)]="value"
     [showTime]="showTime"
     [showFooter]="showFooter"

--- a/src/date-picker/range-picker/range-picker.component.ts
+++ b/src/date-picker/range-picker/range-picker.component.ts
@@ -49,7 +49,7 @@ export class RangePickerComponent extends CommonFormControl<
   clearText: string;
 
   @Input()
-  format = 'YYYY-MM-DD';
+  format: string;
 
   @Input()
   showFooter = true;

--- a/src/date-picker/trigger/trigger.template.html
+++ b/src/date-picker/trigger/trigger.template.html
@@ -14,7 +14,7 @@
         style="flex: 1"
         aui-input
         #focusRef
-        [value]="$any(value || [])[0]?.format(format)"
+        [value]="$any($formatValue() || [])[0]"
         [readonly]="true"
         [size]="size"
         (focus)="leftFocus = true"
@@ -29,7 +29,7 @@
       <input
         style="flex: 1"
         aui-input
-        [value]="$any(value || [])[1]?.format(format)"
+        [value]="$any($formatValue() || [])[1]"
         [readonly]="true"
         [size]="size"
         (focus)="rightFocus = true"
@@ -41,7 +41,7 @@
       <input
         aui-input
         auiTooltipType="plain"
-        [value]="$any(value)?.format(format)"
+        [value]="$any($formatValue())"
         [readonly]="true"
         #focusRef
         [size]="size"

--- a/src/i18n/i18n.pipe.ts
+++ b/src/i18n/i18n.pipe.ts
@@ -1,10 +1,4 @@
-import {
-  ChangeDetectorRef,
-  OnDestroy,
-  Pipe,
-  PipeTransform,
-} from '@angular/core';
-import { Subject, takeUntil } from 'rxjs';
+import { Pipe, PipeTransform } from '@angular/core';
 
 import { I18nService } from './i18n.service';
 
@@ -13,24 +7,10 @@ import { I18nService } from './i18n.service';
   pure: false,
   standalone: true,
 })
-export class I18nPipe implements PipeTransform, OnDestroy {
-  private readonly destroy$$ = new Subject<void>();
-
-  constructor(
-    private readonly i18n: I18nService,
-    private readonly cdr: ChangeDetectorRef,
-  ) {
-    this.i18n.localeChange$
-      .pipe(takeUntil(this.destroy$$))
-      .subscribe(() => this.cdr.markForCheck());
-  }
+export class I18nPipe implements PipeTransform {
+  constructor(private readonly i18n: I18nService) {}
 
   transform(value: any, data?: Record<string, string>) {
     return this.i18n.translate(value, data);
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$$.next();
-    this.destroy$$.complete();
   }
 }

--- a/src/i18n/i18n.service.ts
+++ b/src/i18n/i18n.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, computed, inject, isDevMode, signal } from '@angular/core';
 
-import { DatePickerType } from '..';
+import { DatePickerType } from '../date-picker/calendar/constant';
 
 import { I18NInterface, I18NInterfaceToken } from './i18n.type';
 

--- a/stories/rangepicker/basic.component.ts
+++ b/stories/rangepicker/basic.component.ts
@@ -15,7 +15,7 @@ import { I18nService, en, zh } from '@alauda/ui';
     <aui-range-picker
       [(ngModel)]="range"
       required
-      [clearText]="'清除'"
+      [clearText]="'clear' | auiI18n"
     ></aui-range-picker>
     <br />
     Form value: {{ range | json }}

--- a/stories/rangepicker/basic.component.ts
+++ b/stories/rangepicker/basic.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed } from '@angular/core';
 import { Dayjs } from 'dayjs';
 
 import { I18nService, en, zh } from '@alauda/ui';
@@ -6,7 +6,7 @@ import { I18nService, en, zh } from '@alauda/ui';
 @Component({
   template: `
     <div>
-      Current Locale: {{ i18n.i18n.locale }}
+      Current Locale: {{ $locale() }}
       <button (click)="changeLocale()">Toggle</button>
     </div>
 
@@ -25,9 +25,11 @@ import { I18nService, en, zh } from '@alauda/ui';
 export class RangeBasicComponent {
   range: [Dayjs, Dayjs] = null;
 
+  $locale = computed(() => this.i18n.$$i18n().locale);
+
   constructor(public i18n: I18nService) {}
 
   changeLocale() {
-    this.i18n.setI18n(this.i18n.i18n.locale === 'en' ? zh : en);
+    this.i18n.setI18n(this.$locale() === 'en' ? zh : en);
   }
 }

--- a/stories/rangepicker/basic.stories.ts
+++ b/stories/rangepicker/basic.stories.ts
@@ -4,7 +4,7 @@ import { Meta, StoryObj, moduleMetadata } from '@storybook/angular';
 
 import { RangeBasicComponent } from './basic.component';
 
-import { ButtonModule, DatePickerModule } from '@alauda/ui';
+import { ButtonModule, DatePickerModule, I18nModule } from '@alauda/ui';
 
 const meta: Meta<RangeBasicComponent> = {
   title: 'Example/RangePicker',
@@ -18,6 +18,7 @@ const meta: Meta<RangeBasicComponent> = {
         ReactiveFormsModule,
         ButtonModule,
         BrowserAnimationsModule,
+        I18nModule,
       ],
     }),
   ],

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -2,6 +2,7 @@
   "extends": "@1stg/tsconfig/ng-lib",
   "compilerOptions": {
     "baseUrl": ".",
-    "strictNullChecks": false
+    "strictNullChecks": false,
+    "useDefineForClassFields": false
   }
 }


### PR DESCRIPTION
1. 处理 picker-panel 的  header content 溢出问题
2. 处理 picker-panel 的 header 内年月内容的本地化显示顺序, 年/月 或 月/年
3. storybook 预览应用增加全局样式的 reset-browser 用来处理预览应用中 文本按钮与文本 字体不同导致的 baseline 不对齐问题
    > reset-browser cp 的 fe 的 reset-browser , 只是 body 的 bg 为了还原预览应用的原本样式, 使用了 n-10