### PR TITLE
chore: mod tsconfig to use relative path import

### DIFF
--- a/.changeset/polite-guests-dance.md
+++ b/.changeset/polite-guests-dance.md
@@ -1,0 +1,5 @@
+---
+"@alauda/ui": patch
+---
+
+chore: mod tsconfig to use relative path import

--- a/src/date-picker/trigger/trigger.component.ts
+++ b/src/date-picker/trigger/trigger.component.ts
@@ -13,13 +13,11 @@ import {
 } from '@angular/core';
 import { Dayjs } from 'dayjs';
 
-import { I18nPipe } from '../../i18n/i18n.pipe';
+import { I18nPipe, I18nService } from '../../i18n';
 import { IconComponent } from '../../icon/icon.component';
 import { InputComponent } from '../../input/input.component';
 import { ComponentSize } from '../../internal/types';
 import { buildBem } from '../../internal/utils';
-
-import { I18nService } from 'src/i18n';
 
 const bem = buildBem('aui-date-picker-trigger');
 

--- a/stories/input/number-input.component.ts
+++ b/stories/input/number-input.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 
-import { ComponentSize } from 'src';
+import { ComponentSize } from '@alauda/ui';
 
 @Component({
   template: `

--- a/stories/input/search-input.component.ts
+++ b/stories/input/search-input.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 
-import { ComponentSize } from 'src';
+import { ComponentSize } from '@alauda/ui';
 
 @Component({
   template: `

--- a/stories/select/basic.component.ts
+++ b/stories/select/basic.component.ts
@@ -2,7 +2,7 @@ import { NgFor } from '@angular/common';
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
-import { SelectModule } from 'src';
+import { SelectModule } from '@alauda/ui';
 
 @Component({
   standalone: true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,9 +9,8 @@
   ],
   "exclude": ["dist", "release"],
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
-      "@alauda/ui": ["src"]
+      "@alauda/ui": ["./src"]
     },
     "strictNullChecks": false
   },


### PR DESCRIPTION
之前的 `"baseUrl" : "."` 会让编辑器自动导入其他模块时首选绝对路径,导致 build 产物在被其他项目依赖时 `Error: Module not found: Error: Can't resolve 'src/i18n' in '/home/mrlang/Workspace/alauda/alauda-fe/node_modules/@alauda/ui/fesm2022'`  
修改后 `src/i18n` 此类路径将不可用, 编辑器会首选相对路径, storybook 导入组件模块时使用 `@alauda/ui` 
