### PR TITLE
chore: revert tag style modify

### DIFF
--- a/.changeset/fair-dots-nail.md
+++ b/.changeset/fair-dots-nail.md
@@ -1,0 +1,5 @@
+---
+"@alauda/ui": minor
+---
+
+chore: revert tag style modify

--- a/src/select/multi-select/multi-select.component.html
+++ b/src/select/multi-select/multi-select.component.html
@@ -41,8 +41,8 @@
   <aui-tag
     *ngFor="let option of selectedOptions$ | async; trackBy: trackByValue"
     type="info"
-    [round]="false"
-    [border]="false"
+    [round]="true"
+    [border]="true"
     [size]="tagSize"
     [closeable]="!disabled && !option.disabled"
     (close)="removeValue(option.value)"

--- a/src/tag/tag.component.scss
+++ b/src/tag/tag.component.scss
@@ -87,7 +87,7 @@
 
   &--mini {
     padding: 0 use-var(inline-padding-xs);
-    height: 18px;
+    height: 20px;
     @include text-set(s);
 
     &.isRound {
@@ -133,7 +133,7 @@
 
   &--info {
     color: use-rgb(n-2);
-    background-color: use-rgb(n-7);
+    background-color: use-rgb(n-8);
 
     &.hasBorder {
       border-color: use-rgb(n-7);

--- a/src/tag/tag.component.ts
+++ b/src/tag/tag.component.ts
@@ -45,7 +45,7 @@ export class TagComponent {
   invalid = false;
 
   @Input()
-  round = false;
+  round = true;
 
   @Input()
   color = '';

--- a/stories/tag/basic.component.ts
+++ b/stories/tag/basic.component.ts
@@ -97,7 +97,7 @@ export default class TagBasicComponent {
    * 是否为圆角
    */
   @Input()
-  round = false;
+  round = true;
 
   /**
    * hover是下划线

--- a/stories/tag/basic.stories.ts
+++ b/stories/tag/basic.stories.ts
@@ -27,7 +27,7 @@ export const Basic: Story = {
     size: 'medium',
     closeable: false,
     invalid: false,
-    round: false,
+    round: true,
     allowClick: false,
   },
   parameters: {

--- a/stories/tag/tag.mdx
+++ b/stories/tag/tag.mdx
@@ -49,7 +49,7 @@ import * as icon from './icon.stories';
 | size      | ComponentSize | ComponentSize.Medium | 标签大小                                        |
 | color     | string        | -                    | 自定义颜色, `'BORDER_COLOR[,BACKGOUNRD_COLOR]'` |
 | border    | boolean       | false                | 是否添加边框                                    |
-| round     | boolean       | false                | 是否为圆角                                      |
+| round     | boolean       | true                 | 是否为圆角                                      |
 | closeable | boolean       | false                | 是否可以关闭                                    |
 | solid     | boolean       | false                | 是否为实心                                      |
 | invalid   | boolean       | false                | 是否无效                                        |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Tags now display with rounded corners and visible borders by default.
  * Adjusted tag sizing for mini variants and updated background color for info tags.

* **Documentation**
  * Updated documentation and stories to reflect the new default rounded appearance for tags.

* **Chores**
  * Added a changeset to track the update and revert a previous tag style modification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->