### PR TITLE
fix: date format year

### DIFF
--- a/.changeset/little-chefs-relate.md
+++ b/.changeset/little-chefs-relate.md
@@ -1,0 +1,5 @@
+---
+"@alauda/ui": patch
+---
+
+fix: date format year

--- a/src/date-picker/calendar/range-picker-panel/component.ts
+++ b/src/date-picker/calendar/range-picker-panel/component.ts
@@ -107,7 +107,9 @@ export class DateRangePickerPanelComponent extends CommonFormControl<Dayjs[]> {
   leftDateRange = DateNavRange.Month;
   rightDateRange = DateNavRange.Month;
 
-  FOOTER_DATE_FORMAT = 'YYYY-MM-dd';
+  // Angular DatePipe uses CLDR date formats.
+  // `YYYY` represents week-based year and may differ from calendar year near year end.
+  FOOTER_DATE_FORMAT = 'yyyy-MM-dd';
 
   leftAnchor = dayjs();
   rightAnchor = dayjs().add(1, MONTH);


### PR DESCRIPTION
Angular DatePipe 遵循 CLDR 规范，`YYYY` 表示周所属年而非日历年。
在 12 月底（如 12-28 ~ 12-31）会被解析为下一年，导致页面年份展示错误。
<img width="575" height="347" alt="image" src="https://github.com/user-attachments/assets/4e2b4187-47b5-47a9-8389-403afd325d9c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the date format used in the date range picker footer to use the standard calendar-year convention, preventing incorrect year displays near year-end and ensuring consistent date rendering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->