### PR TITLE
fix: date picker nav availability check

### DIFF
--- a/.changeset/big-apricots-punch.md
+++ b/.changeset/big-apricots-punch.md
@@ -1,0 +1,5 @@
+---
+"@alauda/ui": patch
+---
+
+fix: date picker nav availability check

--- a/src/date-picker/calendar/header/component.ts
+++ b/src/date-picker/calendar/header/component.ts
@@ -109,6 +109,9 @@ export class CalendarHeaderComponent {
     const availValue = (
       side === Side.Left ? this._minAvail : this._maxAvail
     )?.clone();
+    if (!availValue) {
+      return true;
+    }
     /**
      * 对于 range-picker
      * 左侧部分 minAvail = minDate, maxAvail = min(maxData, rightAnchor)，从而左侧部分的按钮，仅在小于右侧部分时显示
@@ -118,14 +121,14 @@ export class CalendarHeaderComponent {
       return type === DateNavRange.Month
         ? !this.anchor.subtract(1, 'month').isBefore(availValue, 'month')
         : type === DateNavRange.Year
-        ? !this.anchor.subtract(1, 'year').isBefore(availValue, 'year')
-        : false;
+          ? !this.anchor.subtract(1, 'year').isBefore(availValue, 'year')
+          : false;
     }
     return type === DateNavRange.Month
       ? !this.anchor.add(1, 'month').isAfter(availValue, 'month')
       : type === DateNavRange.Year
-      ? !this.anchor.add(1, 'year').isAfter(availValue, 'year')
-      : false;
+        ? !this.anchor.add(1, 'year').isAfter(availValue, 'year')
+        : false;
   }
 
   // @return isBetween|isEqual:0, isBefore:-1,isAfter:1
@@ -141,8 +144,8 @@ export class CalendarHeaderComponent {
     return constrainValue.isSame(range.start, MONTH)
       ? 0
       : constrainValue.isBefore(range.start, MONTH)
-      ? -1
-      : 1;
+        ? -1
+        : 1;
   }
 
   navHead(range: DateNavRange, value: number) {


### PR DESCRIPTION
未设置 min max Date 会导致导航切上下年及月按钮不可见。调整为不设置不限制
<img width="653" height="445" alt="image" src="https://github.com/user-attachments/assets/07438831-683f-4fdb-8836-bc5fa67a172e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved an issue with date picker navigation availability checks when availability parameters are not specified.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->