### PR TITLE
chore: config v9 release workflow

### DIFF
--- a/.changeset/clean-jobs-grab.md
+++ b/.changeset/clean-jobs-grab.md
@@ -1,0 +1,7 @@
+---
+"@alauda/ui": patch
+---
+
+fix: configure v9 release workflow
+
+Fix the `release/v9` release workflow so v9 stable releases publish with the `v9` tag and v9 pull request prereleases publish with the `v9-beta` tag.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,7 +9,7 @@
   "commit": false,
   "linked": [],
   "access": "restricted",
-  "baseBranch": "master",
+  "baseBranch": "release/v9",
   "updateInternalDependencies": "minor",
   "ignore": []
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,10 @@ name: Release
 on:
   push:
     branches:
-      - master
+      - release/v9
   pull_request:
     branches:
-      - master
+      - release/v9
   workflow_dispatch:
     inputs:
       version:
@@ -44,8 +44,8 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          commit: 'chore: release @alauda/ui'
-          title: 'chore: release @alauda/ui'
+          commit: 'chore: release @alauda/ui v9'
+          title: 'chore: release @alauda/ui v9'
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: yarn release
         env:
@@ -55,7 +55,7 @@ jobs:
         if: github.event_name == 'pull_request'
         run: sh scripts/release.sh
         env:
-          PUBLISH_VERSION: beta
+          PUBLISH_VERSION: v9-beta
 
       - name: Set git info
         if: github.event_name == 'workflow_dispatch'

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lint:tsc": "tsc -p . --noEmit",
     "prepare": "patch-package && simple-git-hooks && touch documentation.json && yarn-deduplicate --strategy fewer || exit 0",
     "prerelease": "yarn build",
-    "release": "changeset publish",
+    "release": "changeset publish --tag v9",
     "start": "yarn storybook",
     "storybook": "ng run storybook:storybook",
     "storybook:build": "ng run storybook:build-storybook",

--- a/scripts/npm-tag.js
+++ b/scripts/npm-tag.js
@@ -2,7 +2,9 @@ const { getProdVersion } = require('./utils');
 
 const version = process.env.PUBLISH_VERSION;
 
-if (version.includes('-prod-')) {
+if (version === 'v9-beta') {
+  process.stdout.write('v9-beta');
+} else if (version.includes('-prod-')) {
   process.stdout.write(getProdVersion(version));
 } else if (version === 'beta' || /-beta[._-]?\d*$/.test(version)) {
   process.stdout.write('beta');

--- a/scripts/publish-version.js
+++ b/scripts/publish-version.js
@@ -2,24 +2,56 @@ const { execSync } = require('node:child_process');
 
 const semver = require('semver');
 
-let version = process.env.PUBLISH_VERSION || 'patch';
+const { version: packageVersion } = require('../package.json');
 
-if (version.startsWith('v')) {
-  version = version.slice(1);
-} else if (version === 'beta') {
-  const distTags = JSON.parse(
-    execSync('yarn info @alauda/ui dist-tags --json').toString(),
+const PACKAGE_NAME = '@alauda/ui';
+
+function getNpmInfo(field) {
+  const info = JSON.parse(
+    execSync(`yarn info ${PACKAGE_NAME} ${field} --json`).toString(),
   );
 
-  const { beta, latest } = distTags.data || distTags;
+  return info.data || info;
+}
 
-  if (semver.gt(beta, latest)) {
-    version = beta.endsWith('-beta')
-      ? beta + '.0'
-      : beta.replace(/(-beta\.)(\d+)$/, (_, $0, $1) => $0 + (+$1 + 1));
-  } else {
-    version = semver.minVersion(`>${latest}`) + '-beta';
+function getNextBetaVersion(stable, versions) {
+  const nextBeta = semver.minVersion(`>${stable}`) + '-beta';
+  const nextVersion = semver.parse(nextBeta);
+  const candidates = versions
+    .filter(Boolean)
+    .filter(candidate => {
+      const parsed = semver.parse(candidate);
+
+      return (
+        parsed &&
+        parsed.major === nextVersion.major &&
+        parsed.minor === nextVersion.minor &&
+        parsed.patch === nextVersion.patch &&
+        parsed.prerelease[0] === 'beta'
+      );
+    })
+    .sort(semver.rcompare);
+
+  const latestBeta = candidates[0];
+
+  if (!latestBeta) {
+    return nextBeta;
   }
+
+  return latestBeta.endsWith('-beta')
+    ? latestBeta + '.0'
+    : latestBeta.replace(/(-beta\.)(\d+)$/, (_, $0, $1) => $0 + (+$1 + 1));
+}
+
+let version = process.env.PUBLISH_VERSION || 'patch';
+
+if (version === 'beta' || version === 'v9-beta') {
+  const versions = getNpmInfo('versions');
+  const stable = process.env.PUBLISH_BETA_BASE_VERSION || packageVersion;
+
+  version = getNextBetaVersion(stable, versions);
+} else if (version.startsWith('v')) {
+  version = version.slice(1);
 }
 
 process.stdout.write(version);

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,9 +2,10 @@
 
 set -e
 
+REQUESTED_PUBLISH_VERSION=$PUBLISH_VERSION
 PUBLISH_VERSION=$(node scripts/publish-version)
 PUBLISH_BRANCH=$(node scripts/publish-branch)
-NPM_TAG=$(node scripts/npm-tag)
+NPM_TAG=$(PUBLISH_VERSION="$REQUESTED_PUBLISH_VERSION" node scripts/npm-tag)
 
 if [ "$NPM_TAG" = "latest" ]; then
   echo "Publish latest tag via this script is not permitted anymore."


### PR DESCRIPTION
release/v9 发布逻辑总结：

  - 正式发布：
      - release PR 分支：changeset-release/release/v9
      - release PR 标题：chore: release @alauda/ui v9
      - changeset base branch：release/v9
      - 当前版本从 9.1.2 继续递增，例如 patch changeset 会发布 9.1.3
      - npm tag：v9
      - 不会更新 latest
  - PR beta 发布：
      - 触发：PR target 是 release/v9
      - workflow 使用：PUBLISH_VERSION=v9-beta
      - 版本号计算：基于 package.json.version 和 npm 已发布 versions
      - 如果已有 9.1.3-beta.3，下一次发布 9.1.3-beta.4
      - npm tag：v9-beta
      - 不使用也不覆盖全局 beta
      - 不会更新 latest
  - 构建：
      - release/v9 仍是 Yarn 1
      - 保留 prerelease: yarn build
      - release: changeset publish --tag v9
      - Yarn 1 会在 yarn release 前自动执行 prerelease
  - 隔离关系：
      - master 发布 v10+，使用 latest
      - release/v9 发布 v9.x，使用 v9
      - release/v9 的 PR beta 使用 v9-beta
      - 两条线的 changelog、release PR 和 dist-tag 都独立，不互相覆盖。